### PR TITLE
Usercleanup undeliverable only list

### DIFF
--- a/admin_users.php
+++ b/admin_users.php
@@ -719,6 +719,12 @@ case 'cleanup':
 		}
 		if (mktime(0, 0, 0, (int) date('m') - $month, (int) date('d'), (int) date('Y')) > $datelogin && $user->getPreference('verified') && $user->getPreference('verified_by_admin') && $user->getPreference('undeliverable')) {
 			$ucnt++;
+			$istKeinVerwalter=false;
+			$gedcoms = Database::prepare("SELECT gedcom_id, setting_value FROM `##user_gedcom_setting` WHERE user_id = ? AND setting_name = 'canedit' AND setting_value IN ('admin','accept','edit')")->execute(array($user->getUserId()))->fetchAll();
+			if (sizeof($gedcoms) == 0) {
+				  $istKeinVerwalter = true;
+			} 
+
 			?>
 			<tr>
 				<td>
@@ -737,9 +743,10 @@ case 'cleanup':
                 </td>
                 <td>
 					<?php echo I18N::translate('User’s account has been inactive too long: ') . FunctionsDate::timestampToGedcomDate($datelogin)->display(); ?>
+					<?php if (!$istKeinVerwalter) { echo '<br>Nicht gesetzt weil: <strong>IST AL-Verwalter.</strong>'; } ?>
 				</td>
 				<td>
-					<input type="checkbox" checked name="del_<?php echo $user->getUserId(); ?>" value="1">
+					<input type="checkbox" <?php if ($user->getPreference('undeliverable') && $istKeinVerwalter ) { echo 'checked'; } ?> name="del_<?php echo $user->getUserId(); ?>" value="1">
 				</td>
 			</tr>
 		<?php

--- a/admin_users.php
+++ b/admin_users.php
@@ -717,7 +717,7 @@ case 'cleanup':
 		} else {
 			$datelogin = (int) $user->getPreference('sessiontime');
 		}
-		if (mktime(0, 0, 0, (int) date('m') - $month, (int) date('d'), (int) date('Y')) > $datelogin && $user->getPreference('verified') && $user->getPreference('verified_by_admin')) {
+		if (mktime(0, 0, 0, (int) date('m') - $month, (int) date('d'), (int) date('Y')) > $datelogin && $user->getPreference('verified') && $user->getPreference('verified_by_admin') && $user->getPreference('undeliverable')) {
 			$ucnt++;
 			?>
 			<tr>

--- a/admin_users.php
+++ b/admin_users.php
@@ -818,7 +818,7 @@ case 'cleanup':
 		</table>
 		<p>
 		<?php if ($ucnt): ?>
-			<input type="submit" value="<?php echo I18N::translate('delete'); ?>">
+			<input type="submit" value="<?php echo "$ucnt "; echo I18N::translate('delete'); ?>">
 			<?php else: ?>
 			<?php echo I18N::translate('Nothing found to cleanup'); ?>
 			<?php endif; ?>


### PR DESCRIPTION
Mit diesen Änderungen werden bei "inaktive Benutzer löschen" nur die
ausgegeben, die den status "undeliverable" haben.

Außer: sie sind als Verwalter einer AL eingetragen. 

```
INSERT INTO `wt_user_setting` (`user_id`, `setting_name`, `setting_value`) VALUES ('90', 'undeliverable', '1');
INSERT INTO `wt_user_setting` (`user_id`, `setting_name`, `setting_value`) VALUES ('1532', 'undeliverable', '1');
INSERT INTO `wt_user_setting` (`user_id`, `setting_name`, `setting_value`) VALUES ('1825', 'undeliverable', '1');
INSERT INTO `wt_user_setting` (`user_id`, `setting_name`, `setting_value`) VALUES ('1970', 'undeliverable', '1');
INSERT INTO `wt_user_setting` (`user_id`, `setting_name`, `setting_value`) VALUES ('2358', 'undeliverable', '1');
INSERT INTO `wt_user_setting` (`user_id`, `setting_name`, `setting_value`) VALUES ('4101', 'undeliverable', '1');

```